### PR TITLE
Fix compile errors for newer BYOND versions

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -192,7 +192,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			return 1
 	return 0
 
-/proc/sign(x)
+/proc/sgn(x)
 	return x!=0?x/abs(x):0
 
 /proc/getline(atom/M,atom/N)//Ultra-Fast Bresenham Line-Drawing Algorithm
@@ -203,8 +203,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	var/dy=N.y-py
 	var/dxabs=abs(dx)//Absolute value of x distance
 	var/dyabs=abs(dy)
-	var/sdx=sign(dx)	//Sign of x distance (+ or -)
-	var/sdy=sign(dy)
+	var/sdx=sgn(dx)	//Sign of x distance (+ or -)
+	var/sdy=sgn(dy)
 	var/x=dxabs>>1	//Counters for steps taken, setting to distance/2
 	var/y=dyabs>>1	//Bit-shifting makes me l33t.  It also makes getline() unnessecarrily fast.
 	var/j			//Generic integer for counting

--- a/code/_helpers/vector.dm
+++ b/code/_helpers/vector.dm
@@ -21,10 +21,10 @@ increment()
 
 return_angle()
 	Returns the direction (angle in degrees) the object is travelling in.
-	* North = 90°
-	* East  = 0°
-	* South = -90°
-	* West  = 180°
+	* North = 90Â°
+	* East  = 0Â°
+	* South = -90Â°
+	* West  = 180Â°
 
 return_hypotenuse()
 	Returns the distance of travel for each step of the vector, relative to each full step of movement. 1 is a full turf 
@@ -83,14 +83,14 @@ return_location()
 	// calculate the offset per increment step
 	if(abs(angle) in list(0, 45, 90, 135, 180))		// check if the angle is a cardinal
 		if(abs(angle) in list(0, 45, 135, 180))		// if so we can skip the trigonometry and set these to absolutes as
-			offset_x = sign(dx)						// they will always be a full step in one or more directions
+			offset_x = sgn(dx)						// they will always be a full step in one or more directions
 		if(abs(angle) in list(45, 90, 135))
-			offset_y = sign(dy)
+			offset_y = sgn(dy)
 	else if(abs(dy) > abs(dx))
 		offset_x = Cot(abs(angle))					// otherwise set the offsets
-		offset_y = sign(dy)
+		offset_y = sgn(dy)
 	else
-		offset_x = sign(dx)
+		offset_x = sgn(dx)
 		offset_y = Tan(angle)
 		if(dx < 0)
 			offset_y = -offset_y

--- a/code/controllers/hooks.dm
+++ b/code/controllers/hooks.dm
@@ -29,10 +29,10 @@
 		error("Invalid hook '/hook/[hook]' called.")
 		return 0
 
-	var/caller = new hook_path
+	var/hook_instance = new hook_path
 	var/status = 1
 	for(var/P in typesof("[hook_path]/proc"))
-		if(!call(caller, P)(arglist(args)))
+		if(!call(hook_instance, P)(arglist(args)))
 			error("Hook '[P]' failed or runtimed.")
 			status = 0
 

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -210,23 +210,22 @@ SUBSYSTEM_DEF(jobs)
 				if(!V.client) continue
 				var/age = V.client.prefs.age
 
-				if(age < job.minimum_character_age) // Nope.
-					continue
+			if(age < job.minimum_character_age) // Nope.
+				continue
 
-				switch(age)
-					if(job.minimum_character_age to (job.minimum_character_age+10))
-						weightedCandidates[V] = 3 // Still a bit young.
-					if((job.minimum_character_age+10) to (job.ideal_character_age-10))
-						weightedCandidates[V] = 6 // Better.
-					if((job.ideal_character_age-10) to (job.ideal_character_age+10))
-						weightedCandidates[V] = 10 // Great.
-					if((job.ideal_character_age+10) to (job.ideal_character_age+20))
-						weightedCandidates[V] = 6 // Still good.
-					if((job.ideal_character_age+20) to INFINITY)
-						weightedCandidates[V] = 3 // Geezer.
-					else
-						// If there's ABSOLUTELY NOBODY ELSE
-						if(candidates.len == 1) weightedCandidates[V] = 1
+			if(age < job.minimum_character_age + 10)
+				weightedCandidates[V] = 3 // Still a bit young.
+			else if(age < job.ideal_character_age - 10)
+				weightedCandidates[V] = 6 // Better.
+			else if(age < job.ideal_character_age + 10)
+				weightedCandidates[V] = 10 // Great.
+			else if(age < job.ideal_character_age + 20)
+				weightedCandidates[V] = 6 // Still good.
+			else if(age >= job.ideal_character_age + 20)
+				weightedCandidates[V] = 3 // Geezer.
+			else
+				// If there's ABSOLUTELY NOBODY ELSE
+				if(candidates.len == 1) weightedCandidates[V] = 1
 
 
 			var/mob/new_player/candidate = pickweight(weightedCandidates)

--- a/code/game/gamemodes/warfare/barricade.dm
+++ b/code/game/gamemodes/warfare/barricade.dm
@@ -152,11 +152,12 @@
 	. = ..()
 
 /obj/structure/defensive_barrier/proc/take_damage(damage)
-	if(damage)
-		playsound(src.loc, 'sound/effects/bang.ogg', 75, 1)
-		damage = round(damage * 0.5)
-		if(damage)
-			..()
+	if(!damage)
+	return
+	playsound(src.loc, 'sound/effects/bang.ogg', 75, 1)
+	var/reduced = round(damage * 0.5)
+	if(reduced)
+	return ..(reduced)
 
 /obj/structure/defensive_barrier/proc/check_cover(obj/item/projectile/P, turf/from)
 	var/turf/cover = get_turf(src)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -99,11 +99,12 @@ LINEN BINS
 	name = "linen bin"
 	desc = "A linen bin. It looks rather cosy."
 	icon = 'icons/obj/structures.dmi'
-	icon_state = "linenbin-full"
-	anchored = 1
-	var/amount = 20
-	var/list/sheets = list()
-	var/obj/item/hidden = null
+icon_state = "linenbin-full"
+anchored = 1
+var/max_sheets = 20
+var/amount = max_sheets
+var/list/sheets = list()
+var/obj/item/hidden = null
 
 
 /obj/structure/bedsheetbin/examine(mob/user)
@@ -119,10 +120,12 @@ LINEN BINS
 
 
 /obj/structure/bedsheetbin/update_icon()
-	switch(amount)
-		if(0)				icon_state = "linenbin-empty"
-		if(1 to amount / 2)	icon_state = "linenbin-half"
-		else				icon_state = "linenbin-full"
+	if(amount <= 0)
+		icon_state = "linenbin-empty"
+	else if(amount <= max_sheets / 2)
+		icon_state = "linenbin-half"
+	else
+		icon_state = "linenbin-full"
 
 
 /obj/structure/bedsheetbin/attackby(obj/item/I as obj, mob/user as mob)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -29,7 +29,8 @@
 
 	var/movement_delay
 
-	var/has_coldbreath = FALSE
+var/has_coldbreath = FALSE
+var/has_light = TRUE
 
 /turf/New()
 	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -116,7 +116,7 @@
 			Stun(2)
 		if(21 to 25)
 			Weaken(2)
-		if(26 to 25)
+		if(26 to 30)
 			Weaken(5)
 		if(31 to INFINITY)
 			Weaken(10) //This should work for now, more is really silly and makes you lay there forever

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -182,21 +182,20 @@
 					else
 						src.healths.icon_state = "health6"
 			else
-				switch(health)
-					if(200 to INFINITY)
-						src.healths.icon_state = "health0"
-					if(150 to 200)
-						src.healths.icon_state = "health1"
-					if(100 to 150)
-						src.healths.icon_state = "health2"
-					if(50 to 100)
-						src.healths.icon_state = "health3"
-					if(0 to 50)
-						src.healths.icon_state = "health4"
-					if(config.health_threshold_dead to 0)
-						src.healths.icon_state = "health5"
-					else
-						src.healths.icon_state = "health6"
+				if(health >= 200)
+					src.healths.icon_state = "health0"
+				else if(health >= 150)
+					src.healths.icon_state = "health1"
+				else if(health >= 100)
+					src.healths.icon_state = "health2"
+				else if(health >= 50)
+					src.healths.icon_state = "health3"
+				else if(health >= 0)
+					src.healths.icon_state = "health4"
+				else if(health >= config.health_threshold_dead)
+					src.healths.icon_state = "health5"
+				else
+					src.healths.icon_state = "health6"
 		else
 			src.healths.icon_state = "health7"
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -290,13 +290,12 @@
 			if(prob(20))
 				to_chat(owner, "<span class='danger'>You feel your face burning and a searing heat in your lungs!</span>")
 
-			switch(breath.temperature)
-				if(species.heat_level_1 to species.heat_level_2)
-					damage = HEAT_GAS_DAMAGE_LEVEL_1
-				if(species.heat_level_2 to species.heat_level_3)
-					damage = HEAT_GAS_DAMAGE_LEVEL_2
-				else
-					damage = HEAT_GAS_DAMAGE_LEVEL_3
+			if(breath.temperature < species.heat_level_2)
+				damage = HEAT_GAS_DAMAGE_LEVEL_1
+			else if(breath.temperature < species.heat_level_3)
+				damage = HEAT_GAS_DAMAGE_LEVEL_2
+			else
+				damage = HEAT_GAS_DAMAGE_LEVEL_3
 
 			if(prob(20))
 				owner.apply_damage(damage, BURN, BP_HEAD, used_weapon = "Excessive Heat")

--- a/install-byond.sh
+++ b/install-byond.sh
@@ -8,7 +8,7 @@ else
   mkdir -p "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}"
   cd "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}"
   echo "Installing DreamMaker to $PWD"
-  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
+  curl -L -A "Mozilla/5.0" "https://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
   unzip -o byond.zip
   cd byond
   make here


### PR DESCRIPTION
## Summary
- rename sign helper to avoid BYOND reserved word
- replace switch ranges using variables with if/else checks
- add missing turf lighting flag and clean up related code

## Testing
- `bash scripts/dm.sh IS12Warfare.dme` *(fails: Couldn't find the DreamMaker executable)*
- `bash install-byond.sh` *(fails: End-of-central-directory signature not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4277c513c832b96deeb71c94514ac